### PR TITLE
Add GitHub Actions workflow for changelog generation

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,13 @@
+name: Changelog
+on:
+  release:
+    types:
+      - created
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "✏️ Generate release changelog"
+        uses: janheinrichmerker/action-github-changelog-generator@v2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
# Pull Request: Add GitHub Changelog Generator Workflow

## Summary
This pull request introduces a new GitHub Actions workflow that automatically generates a changelog whenever a new release is created.

## Why
Changelogs are essential for tracking changes, improvements, and fixes in a project. Automating the generation of a changelog streamlines the release process and ensures that important updates are consistently documented.

## Changes Made
- Created a new workflow file `.github/workflows/changelog.yaml` with the following details:
  - Triggered on the `release` event specifically when a release is created.
  - Configured a job named `changelog` that runs on `ubuntu-latest`.
  - Utilized the `janheinrichmerker/action-github-changelog-generator@v2.3` action to generate the release changelog with the provided GitHub token.

## Closed Issues
- None

This change will help maintain a clear history of updates, making it easier for users to understand what's new in each release.